### PR TITLE
Add the font file path option in BehaviorText

### DIFF
--- a/public/js/primitives/BehaviorText.js
+++ b/public/js/primitives/BehaviorText.js
@@ -15,7 +15,8 @@ export class BehaviorText extends BehaviorMesh {
 		super(props,blox)
 		this.props = props
 		var loader = new THREE.FontLoader();
-		loader.load( 'fonts/helvetiker_bold.typeface.json', this.attachText.bind(this) )
+		let font = props && props.font ? props.font : 'fonts/helvetiker_bold.typeface.json'
+		loader.load( font, this.attachText.bind(this) )
 	}
 
 	attachText(font) {


### PR DESCRIPTION
The font file used in `BehaviorText` is currently hardcoded to *fonts/helvetiker_bold.typeface.json*, and it would be nice if we can optionally specify custom ones through the Blox scene document (just as the `art:` attribute of `BehaviorSky`).  

BTW, now Blox is proving really powerful for composing interactive THREE objects in my WebVR related projects. Many thanks 👍 